### PR TITLE
Including common.js in options panel

### DIFF
--- a/src/options_custom/index.html
+++ b/src/options_custom/index.html
@@ -25,6 +25,7 @@
         <script src="js/classes/fancy-settings.js"></script>
         <script src="i18n.js"></script>
         <script src="js/i18n.js"></script>
+        <script src="../common/common.js"></script>
         <script src="manifest.js"></script>
         <script src="settings.js"></script>
     </head>


### PR DESCRIPTION
This may be a bad idea, but since options_custom lives under src anyway it feels okay and like it might be useful to have available there as well. Please let me know if it violates what extensions are supposed to reach out to or anything.