### PR TITLE
When deleting a node my window scrolled to the top

### DIFF
--- a/src/view/view.js
+++ b/src/view/view.js
@@ -240,7 +240,9 @@ function actionCloseWindow(node_id, node, unused_action_id, unused_action_el)
 function actionDeleteWindow(node_id, node, unused_action_id, unused_action_el)
 {
     actionCloseWindow(node_id, node, unused_action_id, unused_action_el);
+    let scrollOffsets = [window.scrollX, window.scrollY];
     treeobj.delete_node(node_id);
+    window.scrollTo(...scrollOffsets);
     saveTree();
 } //actionDeleteWindow
 


### PR DESCRIPTION
Scrolling down each time was annoying, so I looked into it and found the cause to be jstree seems to think the element is not scrolled but doesn't care about the window, so I cached the current scroll offset before calling and set it back after to correct for jstree incidentally setting it to 0. Ideally the correction would happen there or in a fork, but this works well for me in the meantime. Hopefully the same for you. :)