### PR TITLE
Close window => collapse tree node, at user option

### DIFF
--- a/js/loglevel-3451d42.js
+++ b/js/loglevel-3451d42.js
@@ -1,0 +1,228 @@
+/*! loglevel - v1.4.1 - https://github.com/pimterry/loglevel - (c) 2017 Tim Perry - licensed MIT */
+(function (root, definition) {
+    "use strict";
+    if (typeof define === 'function' && define.amd) {
+        define(definition);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = definition();
+    } else {
+        root.log = definition();
+    }
+}(this, function () {
+    "use strict";
+
+    // Slightly dubious tricks to cut down minimized file size
+    var noop = function() {};
+    var undefinedType = "undefined";
+
+    var logMethods = [
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error"
+    ];
+
+    // Cross-browser bind equivalent that works at least back to IE6
+    function bindMethod(obj, methodName) {
+        var method = obj[methodName];
+        if (typeof method.bind === 'function') {
+            return method.bind(obj);
+        } else {
+            try {
+                return Function.prototype.bind.call(method, obj);
+            } catch (e) {
+                // Missing bind shim or IE8 + Modernizr, fallback to wrapping
+                return function() {
+                    return Function.prototype.apply.apply(method, [obj, arguments]);
+                };
+            }
+        }
+    }
+
+    // Build the best logging method possible for this env
+    // Wherever possible we want to bind, not wrap, to preserve stack traces
+    function realMethod(methodName) {
+        if (typeof console === undefinedType) {
+            return false; // No method possible, for now - fixed later by enableLoggingWhenConsoleArrives
+        } else if (console[methodName] !== undefined) {
+            return bindMethod(console, methodName);
+        } else if (console.log !== undefined) {
+            return bindMethod(console, 'log');
+        } else {
+            return noop;
+        }
+    }
+
+    // These private functions always need `this` to be set properly
+
+    function replaceLoggingMethods(level, loggerName) {
+        /*jshint validthis:true */
+        for (var i = 0; i < logMethods.length; i++) {
+            var methodName = logMethods[i];
+            this[methodName] = (i < level) ?
+                noop :
+                this.methodFactory(methodName, level, loggerName);
+        }
+    }
+
+    // In old IE versions, the console isn't present until you first open it.
+    // We build realMethod() replacements here that regenerate logging methods
+    function enableLoggingWhenConsoleArrives(methodName, level, loggerName) {
+        return function () {
+            if (typeof console !== undefinedType) {
+                replaceLoggingMethods.call(this, level, loggerName);
+                this[methodName].apply(this, arguments);
+            }
+        };
+    }
+
+    // By default, we use closely bound real methods wherever possible, and
+    // otherwise we wait for a console to appear, and then try again.
+    function defaultMethodFactory(methodName, level, loggerName) {
+        /*jshint validthis:true */
+        return realMethod(methodName) ||
+               enableLoggingWhenConsoleArrives.apply(this, arguments);
+    }
+
+    function Logger(name, defaultLevel, factory) {
+      var self = this;
+      var currentLevel;
+      var storageKey = "loglevel";
+      if (name) {
+        storageKey += ":" + name;
+      }
+
+      function persistLevelIfPossible(levelNum) {
+          var levelName = (logMethods[levelNum] || 'silent').toUpperCase();
+
+          // Use localStorage if available
+          try {
+              window.localStorage[storageKey] = levelName;
+              return;
+          } catch (ignore) {}
+
+          // Use session cookie as fallback
+          try {
+              window.document.cookie =
+                encodeURIComponent(storageKey) + "=" + levelName + ";";
+          } catch (ignore) {}
+      }
+
+      function getPersistedLevel() {
+          var storedLevel;
+
+          try {
+              storedLevel = window.localStorage[storageKey];
+          } catch (ignore) {}
+
+          // Fallback to cookies if local storage gives us nothing
+          if (typeof storedLevel === undefinedType) {
+              try {
+                  var cookie = window.document.cookie;
+                  var location = cookie.indexOf(
+                      encodeURIComponent(storageKey) + "=");
+                  if (location) {
+                      storedLevel = /^([^;]+)/.exec(cookie.slice(location))[1];
+                  }
+              } catch (ignore) {}
+          }
+
+          // If the stored level is not valid, treat it as if nothing was stored.
+          if (self.levels[storedLevel] === undefined) {
+              storedLevel = undefined;
+          }
+
+          return storedLevel;
+      }
+
+      /*
+       *
+       * Public logger API - see https://github.com/pimterry/loglevel for details
+       *
+       */
+
+      self.levels = { "TRACE": 0, "DEBUG": 1, "INFO": 2, "WARN": 3,
+          "ERROR": 4, "SILENT": 5};
+
+      self.methodFactory = factory || defaultMethodFactory;
+
+      self.getLevel = function () {
+          return currentLevel;
+      };
+
+      self.setLevel = function (level, persist) {
+          if (typeof level === "string" && self.levels[level.toUpperCase()] !== undefined) {
+              level = self.levels[level.toUpperCase()];
+          }
+          if (typeof level === "number" && level >= 0 && level <= self.levels.SILENT) {
+              currentLevel = level;
+              if (persist !== false) {  // defaults to true
+                  persistLevelIfPossible(level);
+              }
+              replaceLoggingMethods.call(self, level, name);
+              if (typeof console === undefinedType && level < self.levels.SILENT) {
+                  return "No console available for logging";
+              }
+          } else {
+              throw "log.setLevel() called with invalid level: " + level;
+          }
+      };
+
+      self.setDefaultLevel = function (level) {
+          if (!getPersistedLevel()) {
+              self.setLevel(level, false);
+          }
+      };
+
+      self.enableAll = function(persist) {
+          self.setLevel(self.levels.TRACE, persist);
+      };
+
+      self.disableAll = function(persist) {
+          self.setLevel(self.levels.SILENT, persist);
+      };
+
+      // Initialize with the right level
+      var initialLevel = getPersistedLevel();
+      if (initialLevel == null) {
+          initialLevel = defaultLevel == null ? "WARN" : defaultLevel;
+      }
+      self.setLevel(initialLevel, false);
+    }
+
+    /*
+     *
+     * Top-level API
+     *
+     */
+
+    var defaultLogger = new Logger();
+
+    var _loggersByName = {};
+    defaultLogger.getLogger = function getLogger(name) {
+        if (typeof name !== "string" || name === "") {
+          throw new TypeError("You must supply a name when creating a logger.");
+        }
+
+        var logger = _loggersByName[name];
+        if (!logger) {
+          logger = _loggersByName[name] = new Logger(
+            name, defaultLogger.getLevel(), defaultLogger.methodFactory);
+        }
+        return logger;
+    };
+
+    // Grab the current global log variable in case of overwrite
+    var _log = (typeof window !== undefinedType) ? window.log : undefined;
+    defaultLogger.noConflict = function() {
+        if (typeof window !== undefinedType &&
+               window.log === defaultLogger) {
+            window.log = _log;
+        }
+
+        return defaultLogger;
+    };
+
+    return defaultLogger;
+}));

--- a/src/common/common.js
+++ b/src/common/common.js
@@ -5,16 +5,17 @@ console.log('TabFern common.js loading');
 const MSG_GET_VIEW_WIN_ID = 'getViewWindowID';
 
 /// Get a boolean setting from options_custom, which uses HTML5 localStorage.
-function getBoolSetting(setting_name)
+function getBoolSetting(setting_name, default_value = false)
 {
     let locStorageValue = localStorage.getItem('store.settings.' + setting_name);
-    if (
-        locStorageValue === null
-        || locStorageValue === "false"
-    ) {
+    if ( locStorageValue === null ) {
+        return default_value;
+    } else if ( locStorageValue === "false" ) {
         return false;
     } else if ( locStorageValue === "true" ) {
         return true;
+    } else {
+        return default_value;
     }
 } //getBoolSetting
 

--- a/src/common/common.js
+++ b/src/common/common.js
@@ -2,6 +2,20 @@
 // in this file.
 console.log('TabFern common.js loading');
 
-var MSG_GET_VIEW_WIN_ID = 'getViewWindowID';
+const MSG_GET_VIEW_WIN_ID = 'getViewWindowID';
+
+/// Get a boolean setting from options_custom, which uses HTML5 localStorage.
+function getBoolSetting(setting_name)
+{
+    let locStorageValue = localStorage.getItem('store.settings.' + setting_name);
+    if (
+        locStorageValue === null
+        || locStorageValue === "false"
+    ) {
+        return false;
+    } else if ( locStorageValue === "true" ) {
+        return true;
+    }
+} //getBoolSetting
 
 // vi: set ts=4 sts=4 sw=4 et ai fo-=o: //

--- a/src/options_custom/index.html
+++ b/src/options_custom/index.html
@@ -7,10 +7,10 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <title id="title"></title>
+        <title id="title">TabFern Settings</title>
         
         <!-- Stylesheets -->
-        <link id="favicon" rel="icon" href="">
+        <link id="favicon" rel="icon" href="/assets/fern16.png">
         <link rel="stylesheet" href="lib/default.css" media="screen">
         <link rel="stylesheet" href="css/main.css" media="screen">
         <link rel="stylesheet" href="css/setting.css" media="screen">
@@ -31,7 +31,7 @@
     </head>
     <body class="no-select">
         <div id="sidebar" class="fancy">
-            <img id="icon" src="" alt=""><h1 id="settings-label"></h1>
+            <img id="icon" src="/assets/fern16.png" alt=""><h1 id="settings-label"></h1>
             <div id="tab-container">
                 <div id="search-container" class="tab">
                     <input id="search" type="search" placeholder="">

--- a/src/options_custom/manifest.js
+++ b/src/options_custom/manifest.js
@@ -1,8 +1,10 @@
-// SAMPLE
+// manifest.js: Settings for TabFern
+// TODO move the names into constants in common.js
 this.manifest = {
-    "name": "My Extension",
-    "icon": "icon.png",
+    "name": "TabFern Settings",
+    "icon": "/assets/fern16.png",
     "settings": [
+        // Information
         {
             "tab": i18n.get("information"),
             "group": i18n.get("login"),
@@ -42,6 +44,18 @@ this.manifest = {
             "label": i18n.get("disconnect"),
             "text": i18n.get("logout")
         },
+
+        // Behaviour.  Yeah, there's a "u" in there!
+        {
+            "tab": i18n.get("Behaviour"),
+            "group": i18n.get("When I..."),
+            "name": "collapse-tree-on-window-close",
+            "type": "checkbox",
+            "label": i18n.get("Close a window, collapse its tree")
+            //"text": i18n.get("x-characters")
+        },
+
+        // Details
         {
             "tab": "Details",
             "group": "Sound",
@@ -132,3 +146,4 @@ this.manifest = {
         ]
     ]
 };
+// vi: set ts=4 sts=4 sw=4 et ai: //

--- a/src/options_custom/manifest.js
+++ b/src/options_custom/manifest.js
@@ -49,6 +49,15 @@ this.manifest = {
         {
             "tab": i18n.get("Behaviour"),
             "group": i18n.get("When I..."),
+            "name": "collapse-trees-on-startup",
+            "type": "checkbox",
+            "label": i18n.get("Start up, collapse all the saved trees")
+            //"text": i18n.get("x-characters")
+        },
+
+        {
+            "tab": i18n.get("Behaviour"),
+            "group": i18n.get("When I..."),
             "name": "collapse-tree-on-window-close",
             "type": "checkbox",
             "label": i18n.get("Close a window, collapse its tree")

--- a/src/view/view.css
+++ b/src/view/view.css
@@ -70,11 +70,19 @@
 /* ////////////////////////////////////////////////////////////////////// */
 /* Tweak up jstree */
 
+/* shrink large favicons to fit, if necessary */
 .jstree-children .jstree-children .jstree-anchor .jstree-icon {
     /* Two jstree-children: don't touch the top-level nodes, only second-level
      * and lower. */
     background-size: cover !important;
-        /* will shrink large icons to fit, if necessary */
+}
+
+/* Hide the action buttons except when the row is hovered.  HACK. */
+.jstree-node a.jstree-hovered ~ i {
+    visibility: visible;
+}
+.jstree-node a ~ i {
+    visibility: hidden;
 }
 
 /* vi: set ts=4 sts=4 sw=4 et ai: */

--- a/src/view/view.html
+++ b/src/view/view.html
@@ -12,6 +12,7 @@
 <script src="/js/jquery-3.2.1.js" type="text/javascript"></script>
 <script src="/js/jstree-3.3.4/jstree.js" type="text/javascript"></script>
 <script src="/js/jstree-actions-cw.js" type="text/javascript"></script>
+<script src="/js/loglevel-3451d42.js" type="text/javascript"></script>
 <script src="../common/common.js" type="text/javascript"></script>
 </head>
 <body class="jstree-default-dark">

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -227,6 +227,11 @@ function actionCloseWindow(node_id, node, unused_action_id, unused_action_el)
     treeobj.set_icon(node_id, true);    //default icon
     twiddleVisibleStyle(node, false);   // remove the visible style
 
+    // Collapse the tree, if the user wants that
+    if(getBoolSetting("collapse-tree-on-window-close")) {
+        treeobj.close_node(node);
+    }
+
     // Mark the tabs in the tree node closed.
     for(let child_node_id of node.children) {
         let child_node = treeobj.get_node(child_node_id);

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -1,4 +1,14 @@
-//view.js
+// view.js
+// Uses jquery, jstree, jstree-actions, loglevel, common.js, all of which are
+// loaded by view.html.
+
+//////////////////////////////////////////////////////////////////////////
+// Setup //
+
+// NOTE: as of writing, log.debug() is a no-op - see
+// https://github.com/pimterry/loglevel/issues/111
+log.setDefaultLevel(log.levels.INFO);
+    // TODO change the default to ERROR or SILENT for production.
 
 //////////////////////////////////////////////////////////////////////////
 // Constants //
@@ -176,12 +186,12 @@ function saveTree(save_visible_windows = true)
     chrome.storage.local.set(to_save,
             function() {
                 if(typeof(chrome.runtime.lastError) === 'undefined') {
-                    //console.log('TabFern: saved OK');
-                    return;
+                    return;     // Saved OK
                 }
-                console.log("TabFern: couldn't save: " +
-                                chrome.runtime.lastError.toString());
-                alert("TabFern: Couldn't save");
+                let msg = "TabFern: couldn't save: " +
+                                chrome.runtime.lastError.toString();
+                log.error(msg);
+                alert(msg);     // The user needs to know
             });
 } //saveTree()
 
@@ -340,7 +350,7 @@ function createNodeForWindow(win, keep)
 
     if(typeof(win.tabs) !== 'undefined') {  // new windows may have no tabs
         for(let tab of win.tabs) {
-            console.log('   ' + tab.id.toString() + ': ' + tab.title);
+            log.info('   ' + tab.id.toString() + ': ' + tab.title);
             createNodeForTab(tab, win_node_id);
         }
     }
@@ -350,11 +360,12 @@ function createNodeForWindow(win, keep)
 
 function createNodeForClosedWindow(win_data)
 {
+    let shouldCollapse = getBoolSetting('collapse-trees-on-startup');
     let win_node_id = treeobj.create_node(null,
             {   text: win_data.text
                 //, 'icon': 'visible-window-icon'   // use the default icon
                 , li_attr: { class: WIN_CLASS }
-                , state: { 'opened': true }
+                , state: { 'opened': !shouldCollapse }
                 , data: winState(false, true)   // true => keep
             });
 
@@ -364,7 +375,7 @@ function createNodeForClosedWindow(win_data)
 
     if(typeof(win_data.tabs) !== 'undefined') {
         for(let tab_data of win_data.tabs) {
-            //console.log('   ' + tab_data.text);
+            //log.info('   ' + tab_data.text);
             createNodeForClosedTab(tab_data, win_node_id);
         }
     }
@@ -382,8 +393,8 @@ function loadSavedWindowsIntoTree(next_action)
             let parsed = items[STORAGE_KEY];    // auto JSON.parse
             if(Array.isArray(parsed)) {
 
-                //console.log('Loading:');
-                //console.log(parsed);
+                //log.info('Loading:');
+                //log.info(parsed);
 
                 for(let win_data of parsed) {
                     createNodeForClosedWindow(win_data);
@@ -398,7 +409,7 @@ function loadSavedWindowsIntoTree(next_action)
     });
 } //loadSavedWindowsIntoTree
 
-// Debug helper
+// Debug helper, so uses console.log() directly.
 function DBG_printSaveData()
 {
     chrome.storage.local.get(STORAGE_KEY, function(items) {
@@ -419,7 +430,7 @@ function DBG_printSaveData()
 /// with arrow keys and Enter.
 function treeOnSelect(evt, evt_data)
 {
-    //console.log(evt_data.node);
+    //log.info(evt_data.node);
     if(typeof(evt_data.node) === 'undefined') return;
 
     let node = evt_data.node;
@@ -435,7 +446,7 @@ function treeOnSelect(evt, evt_data)
     if(node_data.nodeType == 'tab' && node_data.isOpen) {   // An open tab
         chrome.tabs.highlight({
             windowId: node_data.tab.windowId,
-            tabs: [node_data.tab.index]
+            tabs: [node_data.tab.index]     // Jump to the clicked-on tab
         });
         win_id = node_data.tab.windowId;
 
@@ -488,6 +499,8 @@ function treeOnSelect(evt, evt_data)
 
                 twiddleVisibleStyle(win_node, true);
 
+                treeobj.open_node(win_node);
+
                 for(let idx=0; idx < win.tabs.length; ++idx) {
                     let tab_node_id = win_node.children[idx];
                     let tab_data = treeobj.get_node(tab_node_id).data;
@@ -500,7 +513,7 @@ function treeOnSelect(evt, evt_data)
         );
 
     } else {    // it's a nodeType we don't know how to handle.
-        console.log('treeOnSelect: Unknown node ' + node_data);
+        log.error('treeOnSelect: Unknown node ' + node_data);
     }
 
     if(typeof win_id !== 'undefined') {
@@ -602,6 +615,8 @@ function tabOnMoved(tabid, moveinfo)
     let from_idx = moveinfo.fromIndex;
     let to_idx = moveinfo.toIndex;
 
+    log.info('Tab being moved: ' + tabid);
+
     // Get the parent (window)
     let parent_node_id = nodeid_by_winid[moveinfo.windowId];
     if(typeof parent_node_id === 'undefined') return;
@@ -629,7 +644,7 @@ function tabOnMoved(tabid, moveinfo)
             if(typeof tab_node === 'undefined') return;
 
             // Move the tree node
-            //console.log('Moving tab from ' + from_idx.toString() + ' to ' +
+            //log.info('Moving tab from ' + from_idx.toString() + ' to ' +
             //            to_idx.toString());
 
             // As far as I can tell, in jstree, indices point between list
@@ -678,12 +693,14 @@ function tabOnDetached(tabid, detachinfo)
 {
     // Don't save here?  Do we get a WindowCreated if the tab is not
     // attached to another window?
+    log.info('Tab being detached: ' + tabid);
     //TODO
 } //tabOnDetached
 
 function tabOnAttached(tabid, attachinfo)
 {
     //TODO
+    log.info('Tab being attached: ' + tabid);
     //saveTree();
 } //tabOnAttached
 
@@ -691,27 +708,45 @@ function tabOnRemoved(tabid, removeinfo)
 {
     // If the window is closing, do not remove the tab records.
     // The cleanup will be handled by winOnRemoved().
+    log.info('Tab being removed: ' + tabid);
     if(removeinfo.isWindowClosing) return;
 
-    // Get the parent (window)
-    let parent_node_id = nodeid_by_winid[removeinfo.windowId];
-    if(typeof parent_node_id === 'undefined') return;
-    let parent_node = treeobj.get_node(parent_node_id);
-    if(typeof parent_node === 'undefined') return;
+    {   // Keep the locals here out of the scope of the closure below.
+        // Get the parent (window)
+        let parent_node_id = nodeid_by_winid[removeinfo.windowId];
+        if(typeof parent_node_id === 'undefined') return;
+        let parent_node = treeobj.get_node(parent_node_id);
+        if(typeof parent_node === 'undefined') return;
 
-    // Get the tab's node
-    let tab_node_id = nodeid_by_tabid[tabid];
-    if(typeof tab_node_id === 'undefined') return;
-    let tab_node = treeobj.get_node(tab_node_id);
-    if(typeof tab_node === 'undefined') return;
+        // Get the tab's node
+        let tab_node_id = nodeid_by_tabid[tabid];
+        if(typeof tab_node_id === 'undefined') return;
+        let tab_node = treeobj.get_node(tab_node_id);
+        if(typeof tab_node === 'undefined') return;
 
-    // Remove the node
-    nodeid_by_tabid[tabid] = undefined;
-        // So any events that are triggered won't try to look for a
-        // nonexistent tab.
-    treeobj.delete_node(tab_node);
+        // Remove the node
+        nodeid_by_tabid[tabid] = undefined;
+            // So any events that are triggered won't try to look for a
+            // nonexistent tab.
+        treeobj.delete_node(tab_node);
+    }
 
-    // TODO if this was the last tab in the window, delete the window.
+    // Refresh the tab.index values for the remaining tabs
+    chrome.windows.get(removeinfo.windowId, {populate: true},
+        function(win) {
+            if((!Array.isArray(win.tabs)) || (win.tabs.length==0)) return;
+
+            for(let remaining_tab of win.tabs) {
+
+                let rtab_node_id = nodeid_by_tabid[remaining_tab.id];
+                if(typeof rtab_node_id === 'undefined') continue;
+                let rtab_node = treeobj.get_node(rtab_node_id);
+                if(typeof rtab_node === 'undefined') continue;
+
+                rtab_node.data.tab.index = remaining_tab.index;
+            }
+        }
+    );
 
     saveTree();
 } //tabOnRemoved
@@ -742,17 +777,16 @@ function eventOnResize(evt)
     // saving until the user is actually done resizing.
     resize_save_timer_id = window.setTimeout(
         function() {
-            console.log('Saving new size ' + size_data.toString());
+            log.info('Saving new size ' + size_data.toString());
 
             let to_save = {};
             to_save[LOCN_KEY] = size_data;
             chrome.storage.local.set(to_save,
                     function() {
                         if(typeof(chrome.runtime.lastError) === 'undefined') {
-                            //console.log('TabFern: saved OK');
-                            return;
+                            return;     // Saved OK
                         }
-                        console.log("TabFern: couldn't save location: " +
+                        log.error("TabFern: couldn't save location: " +
                                         chrome.runtime.lastError.toString());
                     });
         },
@@ -808,7 +842,7 @@ function addOpenWindowsToTree(winarr)
     let focused_win_id;
 
     for(let win of winarr) {
-        //console.log('Window ' + win.id.toString());
+        //log.info('Window ' + win.id.toString());
         if(win.focused) {
             focused_win_id = win.id;
         }
@@ -833,13 +867,13 @@ function initTree2()
 function initTree1(win_id)
 { //called as a callback from sendMessage
     if(typeof(chrome.runtime.lastError) !== 'undefined') {
-        console.log("Couldn't get win ID: " + chrome.runtime.lastError);
+        log.error("Couldn't get win ID: " + chrome.runtime.lastError);
         // TODO add a "couldn't load" message to the popup.
         return;     // This actually is fatal.
     }
     my_winid = win_id;
 
-    console.log('TabFern view.js initializing tree in window ' + win_id.toString());
+    log.info('TabFern view.js initializing tree in window ' + win_id.toString());
 
     // Create the tree
     $('#maintree').jstree({
@@ -865,8 +899,8 @@ function initTree1(win_id)
 
 function initTree0()
 {
-    console.log('TabFern view.js initializing view');
-    //console.log($('#maintree').toString());
+    log.info('TabFern view.js initializing view');
+    //log.info($('#maintree').toString());
 
     chrome.runtime.sendMessage(MSG_GET_VIEW_WIN_ID, initTree1);
 


### PR DESCRIPTION
It's a convenience for me: when I close a window, I assume I don't want its tabs, so the tree node collapses.  However, this is at user option, since others may want different behaviour.  Let me know if you have any concerns; I'll merge this tomorrow if not.

Also:

 - I grabbed the get-bool-setting function from right-click-context-menu and put it in common.js.
 - I put the icon on the settings page so it looks slightly better!