### PR TITLE
Init failure => error message, and don't save.

### DIFF
--- a/src/view/view.css
+++ b/src/view/view.css
@@ -2,14 +2,17 @@
 
 /* DEBUG */
 
-.actiongroup { background-color: #880; }
-
 /* //////////////////////////////////////////////////////////////////// */
 /* Local styles */
 
 .tabfern-popup-footer {
     position:fixed;
     bottom:0px;
+}
+
+.tabfern-popup-footer a {
+    color: #888;
+    text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.5);  /* from jstree */
 }
 
 /* The browser window that currently has focus */
@@ -25,6 +28,13 @@
 
 .action-margin {
     padding-left: 0.4em;
+}
+
+div#init-incomplete {
+    display: none;      /* initially */
+    font-size: large;
+    font-weight: bold;
+    color: #f33;
 }
 
 /* Action buttons --------------------------------------------------------- */

--- a/src/view/view.html
+++ b/src/view/view.html
@@ -18,9 +18,13 @@
 <body class="jstree-default-dark">
 <div id="maintree"></div><!-- the window tree -->
 <div id="view-messages"></div><!-- for error messages -->
+<div id="init-incomplete">Initialization did not complete.  Changes will not
+be saved.</div><!-- hidden if init does complete. -->
 <div class="tabfern-popup-footer">
-<a href="http://www.famfamfam.com/lab/icons/silk/">Icons by famfamfam</a>
+    <a target="_blank" href="https://cxw42.github.io/TabFern/">About, help,
+        and credits</a>
 </div>
 <script src="view.js" type="text/javascript"></script>
 </body>
 </html>
+<!-- vi: set ts=4 sts=4 sw=4 et ai: -->


### PR DESCRIPTION
This way we won't overwrite saved tab data with empty data.  Empty data can happen, e.g., if a bug during initialization prevents control from reaching [`loadSavedWindowsIntoTree`](https://github.com/cxw42/TabFern/blob/pr/init-check/src/view/view.js#L405).
Fixes #17.