### PR TITLE
Fixes in onTabReplaced()

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,12 @@ A good example is [this commit](https://github.com/cxw42/TabFern/commit/3ac0f274
      for more documentation of the available options.
    - Edit the values appropriately.
 
+### Miscellaneous
+
+- If you add a name ending with `id` (in any case), and it's not all
+  upper-case, please spell it `Id` rather than `ID` or `id`.  That will help
+  avoid bugs like #304.  Thanks!
+
 ## Notes about dependencies
 
 The following dev dependencies are listed in `package.json` but **not used**

--- a/app/bg/background.js
+++ b/app/bg/background.js
@@ -18,7 +18,7 @@ const S = require('common/setting-definitions');    // in app/
 
 /// The module exports, for use in command-line debugging
 let me = {
-    viewWindowID: undefined,    // the chrome.windows ID of our view
+    viewWindowId: undefined,    // the chrome.windows ID of our view
     loadView: undefined,
 };
 
@@ -46,8 +46,8 @@ me.loadView = function loadView()
             // However, Firefox does support windows.update with focused.
         },
         function(win) {
-            me.viewWindowID = win.id;
-            console.log('TabFern new View ID: ' + me.viewWindowID.toString());
+            me.viewWindowId = win.id;
+            console.log('TabFern new View ID: ' + me.viewWindowId.toString());
             chrome.windows.update(win.id, {focused:true}, ignore_chrome_error);
         });
 } //loadView()
@@ -63,8 +63,8 @@ function moveTabFernViewToWindow(reference_cwin)
     function clip(x, lo, hi) { if(hi<lo) hi=lo; return Math.min(hi, Math.max(lo, x)); }
 
     if(!isLastError()) {
-        if(!me.viewWindowID) return;
-        chrome.windows.get(me.viewWindowID, function(view_cwin) {
+        if(!me.viewWindowId) return;
+        chrome.windows.get(me.viewWindowId, function(view_cwin) {
             // TODO handle Chrome error
             let updates = {left: reference_cwin.left+16,
                             top: reference_cwin.top+16,
@@ -75,7 +75,7 @@ function moveTabFernViewToWindow(reference_cwin)
             updates.width = clip(view_cwin.width, 200, reference_cwin.width-32);
             updates.height = clip(view_cwin.height, 100, reference_cwin.height-32);
 
-            chrome.windows.update(me.viewWindowID, updates
+            chrome.windows.update(me.viewWindowId, updates
                 // TODO handle Chrome error
                 );
         });
@@ -88,19 +88,19 @@ function moveTabFernViewToWindow(reference_cwin)
 // When the icon is clicked in Chrome
 let onClickedListener = function(tab) {
 
-    // If viewWindowID is undefined then there isn't a popup currently open.
-    if (typeof me.viewWindowID === "undefined") {        // Open the popup
+    // If viewWindowId is undefined then there isn't a popup currently open.
+    if (typeof me.viewWindowId === "undefined") {        // Open the popup
         me.loadView();
     } else {                                // There's currently a popup open
      // Bring it to the front so the user can see it
-        chrome.windows.update(me.viewWindowID, { "focused": true });
+        chrome.windows.update(me.viewWindowId, { "focused": true });
     }
 
     // Set a timer to bring the window to the front on another click
     // that follows fairly shortly.
     if(tab) {
         let clickListener = function(tab) {
-            if(me.viewWindowID && tab.windowId) {
+            if(me.viewWindowId && tab.windowId) {
                 chrome.windows.get(tab.windowId, moveTabFernViewToWindow);
             }
         };
@@ -130,9 +130,9 @@ chrome.commands.onCommand.addListener(onCommandListener);
 // When a window is closed
 chrome.windows.onRemoved.addListener(function(windowId) {
   // If the window getting closed is the popup we created
-  if (windowId === me.viewWindowID) {
-    // Set viewWindowID to undefined so we know the popup is not open
-    me.viewWindowID = undefined;
+  if (windowId === me.viewWindowId) {
+    // Set viewWindowId to undefined so we know the popup is not open
+    me.viewWindowId = undefined;
     console.log('Popup window was closed');
   }
 });
@@ -182,8 +182,8 @@ function messageListener(request, sender, sendResponse)
     }
 
     if(request.msg === MSG_GET_VIEW_WIN_ID && !request.response) {
-        console.log('Responding with window ID ' + me.viewWindowID.toString());
-        sendResponse({msg: request.msg, response: true, id: me.viewWindowID});
+        console.log('Responding with window ID ' + me.viewWindowId.toString());
+        sendResponse({msg: request.msg, response: true, id: me.viewWindowId});
     }
 } //messageListener
 

--- a/app/settings/manifest.js
+++ b/app/settings/manifest.js
@@ -490,6 +490,7 @@ setting_definitions.push(
             "type": "description",
             "text": (
 `<ul>
+<li>Bugfixes ${issue(304)}</li>
 </ul>
 `
             ),

--- a/app/settings/manifest.js
+++ b/app/settings/manifest.js
@@ -485,6 +485,18 @@ alphabetical order within each category.`
 setting_definitions.push(
         {
             "tab": future_i18n("What's new?"),
+            "group": `Version 0.3.1${brplain('20XX-XX-XX')}`,
+            'group_html':true,
+            "type": "description",
+            "text": (
+`<ul>
+</ul>
+`
+            ),
+
+        },
+        {
+            "tab": future_i18n("What's new?"),
             "group": `Version 0.3.0${brplain('2022-12-09')}`,
             'group_html':true,
             "type": "description",

--- a/app/win/main_tl.js
+++ b/app/win/main_tl.js
@@ -2745,8 +2745,7 @@ function onTabReplaced(addedTabId, removedTabId)
     const errmsg = M.react_onTabReplaced(addedTabId, removedTabId);
 
     if(typeof(errmsg) === 'string') {
-        log.warn(`Could not replace ${removedTabId} with ${addedTabId}: ${errmsg}`);
-        return;
+        throw new Error(`Could not replace ${removedTabId} with ${addedTabId}: ${errmsg}`);
     }
 } //onTabReplaced
 

--- a/app/win/main_tl.js
+++ b/app/win/main_tl.js
@@ -2742,15 +2742,11 @@ function onTabReplaced(addedTabId, removedTabId)
 {
     log.info(`Tab being replaced: ${removedTabId} -> ${addedTabId}`);
 
-    const errmsg = M.react_onTabReplaced(addedTabID, removedTabId);
+    const errmsg = M.react_onTabReplaced(addedTabId, removedTabId);
 
     if(typeof(errmsg) === 'string') {
         log.warn(`Could not replace ${removedTabId} with ${addedTabId}: ${errmsg}`);
         return;
-    } else {
-        log.debug({
-            [`Tab replacement ${removedTabId}->${addedTabId}: new value`]:tab_val
-        });
     }
 } //onTabReplaced
 

--- a/app/win/main_tl.js
+++ b/app/win/main_tl.js
@@ -183,7 +183,7 @@ function escapeRegExp(string) {
 
 /// Get the node ID from a NEW_TAB_URL.  Returns falsy on failure, or the ID
 /// on success.
-function getNewTabNodeID(ctab) {
+function getNewTabNodeId(ctab) {
     if(!ctab || !(ctab.url || ctab.pendingUrl)) return false;
     let hash;
     try {
@@ -203,7 +203,7 @@ function getNewTabNodeID(ctab) {
     }
 
     return hash;
-} //getNewTabNodeID
+} //getNewTabNodeId
 
 ////////////////////////////////////////////////////////////////////////// }}}1
 // General record helpers // {{{1
@@ -2541,7 +2541,7 @@ var onTabCreated = (function(){     // search key: function onTabCreated()
     /// @return {Boolean} true if we handled the action, false otherwise
     function handle_tabfern_action(tab_val, ctab)
     {
-        let tab_node_id = getNewTabNodeID(ctab);
+        let tab_node_id = getNewTabNodeId(ctab);
         if(!tab_node_id) return false;      // Not a NEW_TAB_URL
 
         // See if the hash is a node ID for a tab.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabfern",
-  "version": "0.3.0",
+  "version": "0.3.1-pre.2",
   "description": "Google Chrome extension for displaying, saving, and managing tabs",
   "main": "src/view/main.js",
   "directories": {

--- a/vendor/common.js
+++ b/vendor/common.js
@@ -13,7 +13,7 @@ console.log('TabFern common.js loading');
 // { msg: <one of the below constants> [, anything else] }
 // For responses, response:true is also included.
 
-const MSG_GET_VIEW_WIN_ID = 'getViewWindowID';
+const MSG_GET_VIEW_WIN_ID = 'getViewWindowId';
 const MSG_EDIT_TAB_NOTE = 'editTabNote';
 
 ////////////////////////////////////////////////////////////////////////// }}}1


### PR DESCRIPTION
- [x] Pending confirmation from the reporter.

Includes:
- Typo fixes
- Throw rather than warning on failures.
- Standardize on `Id` as a suffix in TF code (doesn't apply to the DOM, of course) and change the few remaining `ID`s to `Id`.  This will hopefully reduce the chance a bug like this will recur.

Fixes #304.
