### PR TITLE
Split setting definitions from setting accessors [refactor] (#334)

### DIFF
--- a/app/bg/background.js
+++ b/app/bg/background.js
@@ -14,7 +14,7 @@ if(false) { // Vendor files - listed here only so they'll be bundled
     require('process/browser');
 }
 
-const S = require('common/setting-definitions');    // in app/
+const S = require('common/setting-accessors');    // in app/
 
 /// The module exports, for use in command-line debugging
 let me = {

--- a/app/common/setting-accessors.js
+++ b/app/common/setting-accessors.js
@@ -1,0 +1,158 @@
+// app/common/setting-accessors.js - Access to the settings
+// Part of TabFern
+
+const SD = require('common/setting-definitions')
+
+// Setting-related functions // {{{1
+
+const SETTING_PREFIX = 'store.settings.';
+
+/// Get the raw value of a setting.  Returns null if the key doesn't exist.
+/// @param setting_name     A value in SD.names
+function getRawSetting(setting_name)
+{
+    return localStorage.getItem(SETTING_PREFIX + setting_name);
+} //getSetting
+
+/// Get the string value of a setting, if it is a string.
+/// @param setting_name     A value in SD.names
+/// @param default_value    Optional default.  If unspecified or
+///                         undefined, the default from SD.defaults
+///                         is used.
+function getStringSetting(setting_name, default_value = undefined)
+{
+    if(typeof default_value === 'undefined' && setting_name in SD.defaults) {
+        default_value = SD.defaults[setting_name];
+    }
+
+    let locStorageValue = localStorage.getItem(SETTING_PREFIX + setting_name);
+
+    if ( locStorageValue !== null ) {   // key exists
+        // Get the value, which is stored as JSON
+        try {
+            let val = JSON.parse(locStorageValue);
+            if(typeof val === 'string') return val;
+        } catch(e) {
+            // do nothing
+        }
+    }
+
+    // If we get here, we didn't have a value, or didn't have a string.
+    return String(default_value);
+} //getStringSetting
+
+/// Get a boolean setting from the settings page, which uses HTML5 localStorage.
+/// @param setting_name     A value in SD.names
+/// @param default_value    Optional default.  If unspecified or
+///                         undefined, the default from SD.defaults
+///                         is used.
+function getBoolSetting(setting_name, default_value = undefined)
+{
+    if(typeof default_value === 'undefined' && setting_name in SD.defaults) {
+        default_value = SD.defaults[setting_name];
+    }
+
+    let locStorageValue = localStorage.getItem(SETTING_PREFIX + setting_name);
+
+    if ( locStorageValue === null ) {   // nonexistent key
+        return default_value;
+    } else {    // Get the value, which is stored as JSON
+        let str = String(locStorageValue).toLowerCase();
+        if ( str === "false" ) {
+            return false;
+        } else if ( str === "true" ) {
+            return true;
+        } else {
+            return default_value;
+        }
+    }
+} //getBoolSetting
+
+/// Find out whether the given setting from the settings page exists.
+/// @param setting_name     A value in SD.names
+function haveSetting(setting_name)
+{
+    if(!setting_name) return false;
+    return (SETTING_PREFIX + setting_name) in localStorage;
+} //haveSetting()
+
+/// Set a setting (wow!).
+/// @param setting_name {String} A value in SD.names
+/// @param setting_value {mixed} The value, which must be
+/// JSON.stringify()able.
+function setSetting(setting_name, setting_value)
+{
+    // TODO handle exceptions in some reasonable way.
+    localStorage.setItem(
+        SETTING_PREFIX + setting_name,
+        JSON.stringify(setting_value)
+    );  // JSON stringify so we can store more than just strings.
+} //setSetting
+
+/// Set a setting only if it's not already there.  Parameters are as
+/// setSetting().
+function setSettingIfNonexistent(setting_name, setting_value)
+{
+    if(!haveSetting(setting_name)) setSetting(setting_name, setting_value);
+}
+
+/// Custom getter for the current theme name.  This enforces known themes.
+function getThemeName()
+{
+    let theme = getStringSetting(SD.names.CFGS_THEME_NAME);
+    if( theme === 'default' || theme === 'default-dark') return theme;
+    else return SD.defaults[CFGS_THEME_NAME];
+} //getThemeName
+
+////////////////////////////////////////////////////////////////////////// }}}1
+// Exports // {{{1
+
+/// The object we will export
+let me = {
+    // settings (forwarded from setting-definitions)
+    names: SD.names,
+    defaults: SD.defaults,
+    validators: SD.validators,
+
+    // special values settings can take on (forwarded from setting-definitions)
+    OROC_DO: SD.OROC_DO,
+    OROC_DO_NOT: SD.OROC_DO_NOT,
+    TRUE: SD.TRUE,
+    FALSE: SD.FALSE,
+
+    // FAVICON_SOURCE values (forwarded from setting-definitions)
+    FAVICON_SITE: SD.FAVICON_SITE,
+    FAVICON_CHROME: SD.FAVICON_CHROME,
+    FAVICON_DDG: SD.FAVICON_DDG,
+
+    // special accessors
+    isOROC: ()=>(getStringSetting(SD.names.CFG_OPEN_REST_ON_CLICK) === CFG_OROC_DO),
+
+    // functions
+    getRaw: getRawSetting,
+    getString: getStringSetting,
+    getBool: getBoolSetting,
+    have: haveSetting,
+    set: setSetting,
+    setIfNonexistent: setSettingIfNonexistent,
+    getThemeName,
+};
+
+// Each of the names is a property directly on the export object,
+// with /^CFG/ removed for convenience.
+for(let name in SD.names) {
+    me[name.replace(/^CFG_/,'').replace(/^CFG/,'')] = SD.names[name];
+        // CFG_FOO -> FOO; CFGS_FOO -> S_FOO
+
+    // Shorthand for bools: CFG_FOO -> isFOO()
+    if(name.match(/^CFG_/)) {
+        me['is' + name.replace(/^CFG_/,'')] = function() {
+            return getBoolSetting(me.names[name]);
+        }
+    }
+}
+
+module.exports = me;
+
+////////////////////////////////////////////////////////////////////////// }}}1
+// vi: set fo-=o fdm=marker fdl=1: //

--- a/app/common/setting-definitions.js
+++ b/app/common/setting-definitions.js
@@ -1,4 +1,4 @@
-// setting-definitions.js: The TabFern settings, and setting-access functions
+// setting-definitions.js: The TabFern settings
 
 // Names of settings, and their defaults // {{{1
 
@@ -173,108 +173,6 @@ const CFG_DEFAULTS = Object.seal(_DEF);
 const CFG_VALIDATORS = Object.seal(_VAL);
 
 ////////////////////////////////////////////////////////////////////////// }}}1
-// Setting-related functions // {{{1
-
-const SETTING_PREFIX = 'store.settings.';
-
-/// Get the raw value of a setting.  Returns null if the key doesn't exist.
-/// @param setting_name     A value in CFG_NAMES
-function getRawSetting(setting_name)
-{
-    return localStorage.getItem(SETTING_PREFIX + setting_name);
-} //getSetting
-
-/// Get the string value of a setting, if it is a string.
-/// @param setting_name     A value in CFG_NAMES
-/// @param default_value    Optional default.  If unspecified or
-///                         undefined, the default from CFG_DEFAULTS
-///                         is used.
-function getStringSetting(setting_name, default_value = undefined)
-{
-    if(typeof default_value === 'undefined' && setting_name in CFG_DEFAULTS) {
-        default_value = CFG_DEFAULTS[setting_name];
-    }
-
-    let locStorageValue = localStorage.getItem(SETTING_PREFIX + setting_name);
-
-    if ( locStorageValue !== null ) {   // key exists
-        // Get the value, which is stored as JSON
-        try {
-            let val = JSON.parse(locStorageValue);
-            if(typeof val === 'string') return val;
-        } catch(e) {
-            // do nothing
-        }
-    }
-
-    // If we get here, we didn't have a value, or didn't have a string.
-    return String(default_value);
-} //getStringSetting
-
-/// Get a boolean setting from the settings page, which uses HTML5 localStorage.
-/// @param setting_name     A value in CFG_NAMES
-/// @param default_value    Optional default.  If unspecified or
-///                         undefined, the default from CFG_DEFAULTS
-///                         is used.
-function getBoolSetting(setting_name, default_value = undefined)
-{
-    if(typeof default_value === 'undefined' && setting_name in CFG_DEFAULTS) {
-        default_value = CFG_DEFAULTS[setting_name];
-    }
-
-    let locStorageValue = localStorage.getItem(SETTING_PREFIX + setting_name);
-
-    if ( locStorageValue === null ) {   // nonexistent key
-        return default_value;
-    } else {    // Get the value, which is stored as JSON
-        let str = String(locStorageValue).toLowerCase();
-        if ( str === "false" ) {
-            return false;
-        } else if ( str === "true" ) {
-            return true;
-        } else {
-            return default_value;
-        }
-    }
-} //getBoolSetting
-
-/// Find out whether the given setting from the settings page exists.
-/// @param setting_name     A value in CFG_NAMES
-function haveSetting(setting_name)
-{
-    if(!setting_name) return false;
-    return (SETTING_PREFIX + setting_name) in localStorage;
-} //haveSetting()
-
-/// Set a setting (wow!).
-/// @param setting_name {String} A value in CFG_NAMES
-/// @param setting_value {mixed} The value, which must be
-/// JSON.stringify()able.
-function setSetting(setting_name, setting_value)
-{
-    // TODO handle exceptions in some reasonable way.
-    localStorage.setItem(
-        SETTING_PREFIX + setting_name,
-        JSON.stringify(setting_value)
-    );  // JSON stringify so we can store more than just strings.
-} //setSetting
-
-/// Set a setting only if it's not already there.  Parameters are as
-/// setSetting().
-function setSettingIfNonexistent(setting_name, setting_value)
-{
-    if(!haveSetting(setting_name)) setSetting(setting_name, setting_value);
-}
-
-/// Custom getter for the current theme name.  This enforces known themes.
-function getThemeName()
-{
-    let theme = getStringSetting(CFG_NAMES.CFGS_THEME_NAME);
-    if( theme === 'default' || theme === 'default-dark') return theme;
-    else return CFG_DEFAULTS[CFGS_THEME_NAME];
-} //getThemeName
-
-////////////////////////////////////////////////////////////////////////// }}}1
 // Exports // {{{1
 
 /// The object we will export
@@ -294,35 +192,9 @@ let me = {
     FAVICON_SITE,
     FAVICON_CHROME,
     FAVICON_DDG,
-
-    // special accessors
-    isOROC: ()=>(getStringSetting(CFG_NAMES.CFG_OPEN_REST_ON_CLICK) === CFG_OROC_DO),
-
-    // functions
-    getRaw: getRawSetting,
-    getString: getStringSetting,
-    getBool: getBoolSetting,
-    have: haveSetting,
-    set: setSetting,
-    setIfNonexistent: setSettingIfNonexistent,
-    getThemeName,
 };
-
-// Each of the names is a property directly on the export object,
-// with /^CFG/ removed for convenience.
-for(let name in CFG_NAMES) {
-    me[name.replace(/^CFG_/,'').replace(/^CFG/,'')] = CFG_NAMES[name];
-        // CFG_FOO -> FOO; CFGS_FOO -> S_FOO
-
-    // Shorthand for bools: CFG_FOO -> isFOO()
-    if(name.match(/^CFG_/)) {
-        me['is' + name.replace(/^CFG_/,'')] = function() {
-            return getBoolSetting(me.names[name]);
-        }
-    }
-}
 
 module.exports = me;
 
 ////////////////////////////////////////////////////////////////////////// }}}1
-// vi: set fo-=o fdm=marker fdl=0: //
+// vi: set fo-=o fdm=marker fdl=1: //

--- a/app/settings/manifest.js
+++ b/app/settings/manifest.js
@@ -4,7 +4,7 @@
 // Note: the tabs and groups are created in the order they
 // first appear in the manifest.
 
-const S = require('common/setting-definitions');    // in app/
+const S = require('common/setting-accessors');    // in app/
 
 // Shortcuts for frequently-used items
 function icon(cls) { return `<i class="${cls}"></i>`; }

--- a/app/settings/settings.js
+++ b/app/settings/settings.js
@@ -30,7 +30,7 @@ const spectrum = require('spectrum-colorpicker');
 const Spinner = require('spin.js').Spinner;
 const tinycolor = require('tinycolor2');
 
-const S = require('common/setting-definitions');    // in app/
+const S = require('common/setting-accessors');    // in app/
 
 const manifest = require('./manifest');
 window.manifest = manifest; //because fancy-settings pulls from there

--- a/app/win/bypasser.js
+++ b/app/win/bypasser.js
@@ -7,7 +7,7 @@ const $ = require('jquery');
 require('lib/jstree');
 const log_orig = require('loglevel');
 const signals = require('signals');
-const S = require('common/setting-definitions');    // in app/
+const S = require('common/setting-accessors');    // in app/
 
 function loginfo(...args) { log_orig.info('TabFern bypasser.js: ', ...args); };
     // for some reason, log.info.bind(log, ...) would capture the log level

--- a/app/win/item_tree.js
+++ b/app/win/item_tree.js
@@ -6,7 +6,7 @@
 const $ = require('jquery');
 const log = require('loglevel');
 const K = require('./const');
-const S = require('common/setting-definitions');    // in app/
+const S = require('common/setting-accessors');    // in app/
 
 require('lib/jstree');
 require('lib/jstree-actions');

--- a/app/win/main_deps.js
+++ b/app/win/main_deps.js
@@ -42,7 +42,7 @@ module.exports = {
     sorts: require('./sorts'),
     T: require('./item_tree'),
     M: require('./model'),
-    S: require('common/setting-definitions'),    // in app/
+    S: require('common/setting-accessors'),    // in app/
 };
 
 // Other modules used by src/view/tree.js, but not imported above yet:

--- a/app/win/model.js
+++ b/app/win/model.js
@@ -20,7 +20,7 @@
 const $ = require('jquery');
 require('lib/jstree');
 const log = require('loglevel');
-const S = require('common/setting-definitions');    // in app/
+const S = require('common/setting-accessors');    // in app/
 const K = require('./const');
 const D = require('./item_details');
 const T = require('./item_tree');


### PR DESCRIPTION
This will permit background.js to load the setting definitions even when it can no longer use the accessors.