### PR TITLE
Open popup on startup

### DIFF
--- a/app/bg/background.js
+++ b/app/bg/background.js
@@ -17,7 +17,7 @@ if (false) {
     require("process/browser");
 }
 
-const SetupContextMenu = require("bg/context-menu");
+const ContextMenu = require("bg/context-menu");
 const MainWindow = require("bg/main-window");
 const SetupOffscreenDocument = require("bg/offscreen-document");
 
@@ -99,9 +99,15 @@ function offscreenDocumentMessageListener(message, sender, sendResponse) {
 } //offscreenDocumentMessageListener()
 
 //////////////////////////////////////////////////////////////////////////
-// Main //
+// Context menu //
 
-chrome.runtime.onInstalled.addListener(SetupContextMenu);
+// Add the onClick listener here unconditionally per
+// <https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#register-listeners>.
+chrome.contextMenus.onClicked.addListener(ContextMenu.onClick);
+chrome.runtime.onInstalled.addListener(ContextMenu.setup);
+
+//////////////////////////////////////////////////////////////////////////
+// Main //
 
 // Do this before loading the offscreen document
 chrome.runtime.onMessage.addListener(offscreenDocumentMessageListener);

--- a/app/bg/context-menu.js
+++ b/app/bg/context-menu.js
@@ -1,4 +1,5 @@
-// app/bg/context-menu.js: service-worker code for context menu
+// app/bg/context-menu.js: service-worker code for context menu.
+// CAUTION: the caller must register the onClick handler.
 // CC-BY-SA 3.0
 
 let ASQ = require("asynquence-contrib");
@@ -29,7 +30,7 @@ function _handleEditNote(tab) {
     );
 } // _handleEditNote()
 
-function _contextMenuClicked(info, tab) {
+function contextMenuClicked(info, tab) {
     console.log({ contextMenuClicked: info, tab });
 
     switch (info.menuItemId) {
@@ -40,14 +41,12 @@ function _contextMenuClicked(info, tab) {
             console.warn(`Unknown menu item ${info.menuItemId}`);
             break;
     }
-} //_contextMenuClicked
+} //contextMenuClicked
 
 // May be used as a chrome.runtime.onInstalled listener or not,
 // so takes no args.
 function setupContextMenu() {
-    // Add this unconditionally per
-    // <https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#register-listeners>
-    chrome.contextMenus.onClicked.addListener(_contextMenuClicked);
+    console.log("Setting up context menu");
 
     ASQ()
         .try((done) => {
@@ -70,10 +69,10 @@ function setupContextMenu() {
         .or((err) => {
             // Just log --- there's no way for us to recover.
             console.error(`Could not create context-menu item: ${err}`);
-
-            // Do, however, unregister a listener that will never be used.
-            chrome.contextMenus.onClicked.removeListener(_contextMenuClicked);
         });
 } //setupContextMenu
 
-module.exports = setupContextMenu;
+module.exports = {
+    onClick: contextMenuClicked,
+    setup: setupContextMenu,
+};

--- a/app/bg/offscreen-document.js
+++ b/app/bg/offscreen-document.js
@@ -14,7 +14,9 @@ const OFFSCREEN_DOC_URL = chrome.runtime.getURL(
 
 // Set up an offscreen document.  Modified from
 // <https://developer.chrome.com/docs/extensions/reference/api/offscreen#maintain_the_lifecycle_of_an_offscreen_document>
-function setupOffscreenDocument(offscreenUrl) {
+function setupOffscreenDocument() {
+    console.log("Checking whether to set up offscreen document");
+
     // Check all windows controlled by the service worker to see if one
     // of them is the offscreen document with the given URL
     ASQH.NowCC((cbk) => {
@@ -27,7 +29,13 @@ function setupOffscreenDocument(offscreenUrl) {
         );
     })
         .then((done, existingContexts) => {
-            if (existingContexts.length == 0) {
+            if (existingContexts.length != 0) {
+                console.log(
+                    `Offscreen document already exists: ${existingContexts}`
+                );
+            } else {
+                // Create the offscreen document
+                console.log("Creating offscreen document");
                 chrome.offscreen.createDocument(
                     {
                         url: OFFSCREEN_DOC_URL,
@@ -38,6 +46,9 @@ function setupOffscreenDocument(offscreenUrl) {
                     ASQH.CC(done)
                 );
             }
+        })
+        .val(() => {
+            console.log("Created offscreen document");
         })
         .or((err) => {
             console.error(`Could not set up offscreen document: ${err}`);

--- a/app/settings/manifest.js
+++ b/app/settings/manifest.js
@@ -491,6 +491,7 @@ setting_definitions.push(
             "text":
 `
 <ul>
+<li>Bugfix: Open the TF window when the browser starts ${issue(342)}</li>
 <li>Internal changes ${issue([343])}</li>
 </ul>
 `


### PR DESCRIPTION
With the changes in events for MV3, the popup wasn't opening when Chrome started with the extension enabled.  Fix that.

Fixes #342 